### PR TITLE
Add missing markdown types

### DIFF
--- a/confluence.go
+++ b/confluence.go
@@ -253,6 +253,10 @@ func (r *Renderer) RenderNode(w io.Writer, node *bf.Node, entering bool) bf.Walk
 		}
 	case bf.Document:
 		break
+	case bf.HTMLBlock:
+		break
+	case bf.HTMLSpan:
+		break
 	case bf.Paragraph:
 		if !entering {
 			if node.Parent.Type != bf.Item {


### PR DESCRIPTION
HTMLSpan and HTMLBlock types throwing panics if not handled properly.
Made them blank for now cause i don't know if they need special treatment in confluence.