### PR TITLE
Update `github.com/russross/blackfriday` to `v2.0.1`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ go get -u github.com/kentaro-m/blackfriday-confluence
 ## Usage
 ```go
 import (
-  bf "gopkg.in/russross/blackfriday.v2"
+  bf "github.com/russross/blackfriday/v2"
   bfconfluence "github.com/kentaro-m/blackfriday-confluence"
 )
 

--- a/confluence.go
+++ b/confluence.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"io"
 
-	bf "gopkg.in/russross/blackfriday.v2"
+	bf "github.com/russross/blackfriday/v2"
 )
 
 // Renderer is the rendering interface for confluence wiki output.

--- a/confluence_test.go
+++ b/confluence_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	bfconfluence "github.com/kentaro-m/blackfriday-confluence"
-	bf "gopkg.in/russross/blackfriday.v2"
+	bf "github.com/russross/blackfriday/v2"
 )
 
 type testData struct {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/kentaro-m/blackfriday-confluence
 go 1.13
 
 require (
+	github.com/russross/blackfriday/v2 v2.0.1
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
-	gopkg.in/russross/blackfriday.v2 v2.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
+github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
-gopkg.in/russross/blackfriday.v2 v2.0.0 h1:+FlnIV8DSQnT7NZ43hcVKcdJdzZoeCmJj4Ql8gq5keA=
-gopkg.in/russross/blackfriday.v2 v2.0.0/go.mod h1:6sSBNz/GtOm/pJTuh5UmBK2ZHfmnxGbl2NZg1UliSOI=


### PR DESCRIPTION
`github.com/russross/blackfriday` now includes a `go.mod`, so anyone trying to use that module at `v2.0.1` with this module will see an error:
```
go get: gopkg.in/russross/blackfriday.v2@v2.0.1: parsing go.mod:
	module declares its path as: github.com/russross/blackfriday/v2
	        but was required as: gopkg.in/russross/blackfriday.v2
```