### PR TITLE
Fix line feed issue + support hard line break 

### DIFF
--- a/confluence.go
+++ b/confluence.go
@@ -138,7 +138,7 @@ func (r *Renderer) RenderNode(w io.Writer, node *bf.Node, entering bool) bf.Walk
 	case bf.Softbreak:
 		break
 	case bf.Hardbreak:
-		break
+		w.Write(nlBytes)
 	case bf.BlockQuote:
 		if entering {
 			r.out(w, quoteTag)
@@ -270,10 +270,15 @@ func (r *Renderer) RenderNode(w io.Writer, node *bf.Node, entering bool) bf.Walk
 		break
 	case bf.Paragraph:
 		if !entering {
-			if node.Parent.Type != bf.Item {
+			if node.Next != nil && node.Next.Type == bf.Paragraph {
+				w.Write(nlBytes)
+				w.Write(nlBytes)
+			} else {
+				if node.Parent.Type != bf.Item {
+					r.cr(w)
+				}
 				r.cr(w)
 			}
-			r.cr(w)
 		}
 	case bf.Strong:
 		r.out(w, strongTag)

--- a/confluence_test.go
+++ b/confluence_test.go
@@ -27,6 +27,62 @@ func doTest(t *testing.T, tdt []testData) {
 	}
 }
 
+func TestParagraph(t *testing.T) {
+	tdt := []testData{
+		{input: "single paragraph", expected: "single paragraph", extensions: bf.CommonExtensions},
+		{input: `first line\
+second line`, expected: "first line\nsecond line", extensions: bf.CommonExtensions},
+		{input: `first line
+second line
+third line
+fourth line`, expected: "first line\nsecond line\nthird line\nfourth line", extensions: bf.CommonExtensions},
+		{input: `first line\
+second line
+third line\
+
+fourth line`, expected: "first line\nsecond line\nthird line\n\nfourth line", extensions: bf.CommonExtensions},
+		{input: `first line
+second line
+third line
+
+
+fourth line`, expected: "first line\nsecond line\nthird line\n\nfourth line", extensions: bf.CommonExtensions},
+		{input: `first line
+
+second line`, expected: "first line\n\nsecond line", extensions: bf.CommonExtensions},
+	}
+
+	doTest(t, tdt)
+}
+
+func TestHardLineBreak(t *testing.T) {
+	tdt := []testData{
+		{input: `first line\
+second line`, expected: "first line\nsecond line", extensions: bf.CommonExtensions | bf.HardLineBreak},
+		{input: `first line
+second line
+third line
+fourth line`, expected: "first line\nsecond line\nthird line\nfourth line", extensions: bf.CommonExtensions | bf.HardLineBreak},
+		{input: `first line\
+second line
+third line\
+
+fourth line`, expected: "first line\nsecond line\nthird line\n\nfourth line", extensions: bf.CommonExtensions | bf.HardLineBreak},
+		{input: `first line
+
+second line
+third line
+
+
+fourth line`, expected: "first line\n\nsecond line\nthird line\n\nfourth line", extensions: bf.CommonExtensions | bf.HardLineBreak},
+		{input: `first line
+ 
+second line`, expected: "first line\n\nsecond line", extensions: bf.CommonExtensions},
+	}
+
+	doTest(t, tdt)
+}
+
 func TestHeading(t *testing.T) {
 	tdt := []testData{
 		{input: "# Section\n", expected: "h1. Section\n", extensions: bf.CommonExtensions},

--- a/confluence_test.go
+++ b/confluence_test.go
@@ -76,8 +76,8 @@ third line
 
 fourth line`, expected: "first line\n\nsecond line\nthird line\n\nfourth line", extensions: bf.CommonExtensions | bf.HardLineBreak},
 		{input: `first line
- 
-second line`, expected: "first line\n\nsecond line", extensions: bf.CommonExtensions},
+
+second line`, expected: "first line\n\nsecond line", extensions: bf.CommonExtensions | bf.HardLineBreak},
 	}
 
 	doTest(t, tdt)


### PR DESCRIPTION
This PR:
- Fixes #19
- Also adds support for [HardLineBreak](https://github.com/russross/blackfriday/blob/v2/markdown.go#L41) extension.

### Additional details
Given a string
```
first line
second line
third line
fourth line
```

Generated AST without  `HardLineBreak` extension:

```
Document("")
  -> Paragraph("")
    -> Text("first line\nsecond line\nthird line\nfourth line")
```

Generated AST with `HardLineBreak` extension:
```
Document("")
  -> Paragraph("")
    -> Text("first line")
    -> Hardbreak("")
    -> Text("second line")
    -> Hardbreak("")
    -> Text("third line")
    -> Hardbreak("")
    -> Text("fourth line")
```

Output should be same in both cases, which is `first line\nsecond line\nthird line\nfourth line`. Test covers more scenarios.