### PR TITLE
Code Block macro requires `language` parameter to specify the language.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ hoge
 ```
 
 ```
-{code:go}
+{code:language=go}
 package main
 import "fmt"
 func main() {

--- a/confluence.go
+++ b/confluence.go
@@ -164,7 +164,7 @@ func (r *Renderer) RenderNode(w io.Writer, node *bf.Node, entering bool) bf.Walk
 					r.out(w, warningTag)
 				default:
 					r.out(w, []byte(codeTag))
-					r.out(w, []byte(":"))
+					r.out(w, []byte(":language="))
 					r.out(w, node.Info)
 				}
 				r.out(w, []byte("}"))
@@ -185,7 +185,7 @@ func (r *Renderer) RenderNode(w io.Writer, node *bf.Node, entering bool) bf.Walk
 				}
 			} else {
 				r.out(w, []byte(codeTag))
-				r.out(w, []byte(":"))
+				r.out(w, []byte(":language="))
 				r.out(w, node.Info)
 				r.out(w, []byte("}"))
 				r.cr(w)

--- a/confluence_test.go
+++ b/confluence_test.go
@@ -131,12 +131,12 @@ func TestCodeBlock(t *testing.T) {
 		},
 		{
 			input:      "```c\n\nint main(void) {\n printf(\"Hello, world.\"); \n}\n```",
-			expected:   "{code:c}\n\nint main(void) {\n printf(\"Hello, world.\"); \n}\n{code}\n\n",
+			expected:   "{code:language=c}\n\nint main(void) {\n printf(\"Hello, world.\"); \n}\n{code}\n\n",
 			extensions: bf.CommonExtensions,
 		},
 		{
 			input:      "```c\n\nint main(void) {\n printf(\"Hello, world.\"); \n}\n```",
-			expected:   "{code:c}\n\nint main(void) {\n printf(\"Hello, world.\"); \n}\n{code}\n\n",
+			expected:   "{code:language=c}\n\nint main(void) {\n printf(\"Hello, world.\"); \n}\n{code}\n\n",
 			flags:      bfconfluence.InformationMacros,
 			extensions: bf.CommonExtensions,
 		},


### PR DESCRIPTION
Code Block macro requires `language` parameter to specify the language.

https://confluence.atlassian.com/doc/code-block-macro-139390.html

I am happy if you could release `md2confl` when this pull request was merged.

